### PR TITLE
refactor(terraform): remove aws_eks_cluster data source and use oidc_provider_url variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Truefoundry AWS platform features
 | [aws_iam_user_policy_attachment.truefoundry_platform_user_parameter_store_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.truefoundry_platform_user_s3_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.truefoundry_platform_user_secrets_manager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
-| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_iam_policy_document.truefoundry_platform_feature_cluster_integration_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.truefoundry_platform_feature_ecr_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.truefoundry_platform_feature_parameter_store_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -71,6 +70,7 @@ Truefoundry AWS platform features
 | <a name="input_feature_secrets_manager_enabled"></a> [feature\_secrets\_manager\_enabled](#input\_feature\_secrets\_manager\_enabled) | Enable secrets manager feature in the platform | `bool` | `false` | no |
 | <a name="input_flyte_propeller_serviceaccount_name"></a> [flyte\_propeller\_serviceaccount\_name](#input\_flyte\_propeller\_serviceaccount\_name) | Name for the Flyte Propeller service account | `string` | `"flytepropeller"` | no |
 | <a name="input_flyte_propeller_serviceaccount_namespace"></a> [flyte\_propeller\_serviceaccount\_namespace](#input\_flyte\_propeller\_serviceaccount\_namespace) | Namespace for the Flyte Propeller service account | `string` | `"tfy-workflow-propeller"` | no |
+| <a name="input_oidc_provider_url"></a> [oidc\_provider\_url](#input\_oidc\_provider\_url) | OIDC provider URL | `string` | `""` | no |
 | <a name="input_platform_role_enable_override"></a> [platform\_role\_enable\_override](#input\_platform\_role\_enable\_override) | Enable overriding the platform role name. You need to pass blob\_storage\_override\_name to pass the bucket name | `bool` | `false` | no |
 | <a name="input_platform_role_override_name"></a> [platform\_role\_override\_name](#input\_platform\_role\_override\_name) | Platform IAM role name which will have access to S3 bucket, SSM and ECR | `string` | `""` | no |
 | <a name="input_platform_user_enabled"></a> [platform\_user\_enabled](#input\_platform\_user\_enabled) | Enable creation of a platform feature user | `bool` | `false` | no |

--- a/iam.tf
+++ b/iam.tf
@@ -1,7 +1,3 @@
-data "aws_eks_cluster" "cluster" {
-  name = var.cluster_name
-}
-
 data "aws_iam_policy_document" "truefoundry_platform_feature_s3_policy_document" {
   count = var.feature_blob_storage_enabled ? 1 : 0
   statement {

--- a/locals.tf
+++ b/locals.tf
@@ -17,6 +17,6 @@ locals {
   ]
   truefoundry_platform_policy_arns = [for arn in local.policy_arns : tostring(arn) if arn != null]
 
-  oidc_provider_url    = replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")
-  iam_role_name_prefix = trimsuffix(substr("${local.truefoundry_unique_name}-iam-role-", 0, 37), "-")
+  oidc_provider_url    = replace(var.oidc_provider_url, "https://", "")
+  iam_role_name_prefix = substr("${local.truefoundry_unique_name}-iam-role", 0, 37)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "oidc_provider_url" {
+  description = "OIDC provider URL"
+  type        = string
+  default     = ""
+}
+
 ################################################################################
 # Cluster
 ################################################################################


### PR DESCRIPTION
Remove dependency on aws_eks_cluster data source for OIDC provider URL.
Introduce oidc_provider_url variable for more flexibility and modularity.
