### PR TITLE
fixing the logic for oidc provider URL

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -1,3 +1,7 @@
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
 data "aws_iam_policy_document" "truefoundry_platform_feature_s3_policy_document" {
   count = var.feature_blob_storage_enabled ? 1 : 0
   statement {

--- a/locals.tf
+++ b/locals.tf
@@ -17,6 +17,6 @@ locals {
   ]
   truefoundry_platform_policy_arns = [for arn in local.policy_arns : tostring(arn) if arn != null]
 
-  oidc_provider_url    = replace(var.oidc_provider_url, "https://", "")
-  iam_role_name_prefix = substr("${local.truefoundry_unique_name}-iam-role", 0, 37)
+  oidc_provider_url    = var.oidc_provider_url != "" ? replace(var.oidc_provider_url, "https://", "") : replace(data.aws_eks_cluster.cluster.identity[0].oidc[0].issuer, "https://", "")
+  iam_role_name_prefix = trimsuffix(substr("${local.truefoundry_unique_name}-iam-role-", 0, 37), "-")
 }


### PR DESCRIPTION
Fixing the logic of OIDC in trust relationship. If oidc_provider_url is not passed the oidc provider url will be fetched from cluster's data block