### PR TITLE
Refactor IAM role and policy attachment logic to use platform_role_enabled variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Truefoundry AWS platform features
 | <a name="input_platform_features_iam_policy_prefix_enable_override"></a> [platform\_features\_iam\_policy\_prefix\_enable\_override](#input\_platform\_features\_iam\_policy\_prefix\_enable\_override) | Enable overriding the IAM policy prefix. If enabled, you need to pass platform\_features\_iam\_policy\_prefix\_override\_name to pass the prefix | `bool` | `false` | no |
 | <a name="input_platform_features_iam_policy_prefix_override_name"></a> [platform\_features\_iam\_policy\_prefix\_override\_name](#input\_platform\_features\_iam\_policy\_prefix\_override\_name) | Prefix for the IAM policy. If empty, the default prefix will be used. Only used if platform\_features\_iam\_policy\_prefix\_enable\_override is enabled | `string` | `""` | no |
 | <a name="input_platform_role_enable_override"></a> [platform\_role\_enable\_override](#input\_platform\_role\_enable\_override) | Enable overriding the platform role name. You need to pass blob\_storage\_override\_name to pass the bucket name | `bool` | `false` | no |
+| <a name="input_platform_role_enabled"></a> [platform\_role\_enabled](#input\_platform\_role\_enabled) | Enable creation of a platform feature IAM role | `bool` | `true` | no |
 | <a name="input_platform_role_override_name"></a> [platform\_role\_override\_name](#input\_platform\_role\_override\_name) | Platform IAM role name which will have access to S3 bucket, SSM and ECR | `string` | `""` | no |
 | <a name="input_platform_role_permissions_boundary_arn"></a> [platform\_role\_permissions\_boundary\_arn](#input\_platform\_role\_permissions\_boundary\_arn) | ARN of the permissions boundary to apply to the platform role | `string` | `null` | no |
 | <a name="input_platform_user_enabled"></a> [platform\_user\_enabled](#input\_platform\_user\_enabled) | Enable creation of a platform feature user | `bool` | `false` | no |
@@ -110,7 +111,7 @@ Truefoundry AWS platform features
 | <a name="output_platform_ecr_url"></a> [platform\_ecr\_url](#output\_platform\_ecr\_url) | The ECR url to connect |
 | <a name="output_platform_iam_role_arn"></a> [platform\_iam\_role\_arn](#output\_platform\_iam\_role\_arn) | The platform IAM role arn |
 | <a name="output_platform_iam_role_assume_role_arns"></a> [platform\_iam\_role\_assume\_role\_arns](#output\_platform\_iam\_role\_assume\_role\_arns) | The role arns that can assume the platform IAM role |
-| <a name="output_platform_iam_role_enabled"></a> [platform\_iam\_role\_enabled](#output\_platform\_iam\_role\_enabled) | Flag to enable IAM role for the platform. If false, the user will be created. |
+| <a name="output_platform_iam_role_enabled"></a> [platform\_iam\_role\_enabled](#output\_platform\_iam\_role\_enabled) | Flag to enable IAM role for the platform |
 | <a name="output_platform_iam_role_policy_arns"></a> [platform\_iam\_role\_policy\_arns](#output\_platform\_iam\_role\_policy\_arns) | The platform IAM role policy arns |
 | <a name="output_platform_secrets_manager_enabled"></a> [platform\_secrets\_manager\_enabled](#output\_platform\_secrets\_manager\_enabled) | Flag to enable Secrets Manager for the platform |
 | <a name="output_platform_ssm_enabled"></a> [platform\_ssm\_enabled](#output\_platform\_ssm\_enabled) | Flag to enable Parameter Store for the platform |

--- a/iam.tf
+++ b/iam.tf
@@ -192,7 +192,7 @@ resource "aws_iam_policy" "truefoundry_platform_feature_cluster_integration_poli
 ################################################################################
 
 resource "aws_iam_role" "truefoundry_platform_feature_iam_role" {
-  count                 = var.platform_user_enabled ? 0 : 1
+  count                 = var.platform_role_enabled ? 1 : 0
   name                  = var.platform_role_enable_override ? var.platform_role_override_name : null
   description           = "IAM role for TrueFoundry platform to access S3 bucket, SSM, ECR and EKS"
   name_prefix           = var.platform_role_enable_override ? null : local.iam_role_name_prefix
@@ -232,37 +232,37 @@ resource "aws_iam_role" "truefoundry_platform_feature_iam_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "truefoundry_platform_s3_policy_attachment" {
-  count      = var.feature_blob_storage_enabled && !var.platform_user_enabled ? 1 : 0
+  count      = var.feature_blob_storage_enabled && var.platform_role_enabled ? 1 : 0
   role       = aws_iam_role.truefoundry_platform_feature_iam_role[0].name
   policy_arn = aws_iam_policy.truefoundry_platform_feature_s3_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "truefoundry_platform_parameter_store_policy_attachment" {
-  count      = var.feature_parameter_store_enabled && !var.platform_user_enabled ? 1 : 0
+  count      = var.feature_parameter_store_enabled && var.platform_role_enabled ? 1 : 0
   role       = aws_iam_role.truefoundry_platform_feature_iam_role[0].name
   policy_arn = aws_iam_policy.truefoundry_platform_feature_parameter_store_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "truefoundry_platform_secrets_manager_policy_attachment" {
-  count      = var.feature_secrets_manager_enabled && !var.platform_user_enabled ? 1 : 0
+  count      = var.feature_secrets_manager_enabled && var.platform_role_enabled ? 1 : 0
   role       = aws_iam_role.truefoundry_platform_feature_iam_role[0].name
   policy_arn = aws_iam_policy.truefoundry_platform_feature_secrets_manager_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "truefoundry_platform_ecr_policy_attachment" {
-  count      = var.feature_docker_registry_enabled && !var.platform_user_enabled ? 1 : 0
+  count      = var.feature_docker_registry_enabled && var.platform_role_enabled ? 1 : 0
   role       = aws_iam_role.truefoundry_platform_feature_iam_role[0].name
   policy_arn = aws_iam_policy.truefoundry_platform_feature_ecr_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "truefoundry_platform_cluster_integration_policy_attachment" {
-  count      = var.feature_cluster_integration_enabled && !var.platform_user_enabled ? 1 : 0
+  count      = var.feature_cluster_integration_enabled && var.platform_role_enabled ? 1 : 0
   role       = aws_iam_role.truefoundry_platform_feature_iam_role[0].name
   policy_arn = aws_iam_policy.truefoundry_platform_feature_cluster_integration_policy[0].arn
 }
 
 resource "aws_iam_role_policy_attachment" "truefoundry_platform_additional_policy_attachment" {
-  count      = !var.platform_user_enabled ? length(var.platform_features_additional_policy_arns) : 0
+  count      = var.platform_role_enabled ? length(var.platform_features_additional_policy_arns) : 0
   role       = aws_iam_role.truefoundry_platform_feature_iam_role[0].name
   policy_arn = var.platform_features_additional_policy_arns[count.index]
 }

--- a/output.tf
+++ b/output.tf
@@ -4,23 +4,23 @@
 # IAM role details
 ################################################################################
 output "platform_iam_role_enabled" {
-  description = "Flag to enable IAM role for the platform. If false, the user will be created."
-  value       = !var.platform_user_enabled
+  description = "Flag to enable IAM role for the platform"
+  value       = var.platform_role_enabled
 }
 
 output "platform_iam_role_arn" {
   description = "The platform IAM role arn"
-  value       = var.platform_user_enabled ? "" : aws_iam_role.truefoundry_platform_feature_iam_role[0].arn
+  value       = var.platform_role_enabled ? aws_iam_role.truefoundry_platform_feature_iam_role[0].arn : ""
 }
 
 output "platform_iam_role_assume_role_arns" {
   description = "The role arns that can assume the platform IAM role"
-  value       = var.platform_user_enabled ? [] : var.control_plane_roles
+  value       = var.platform_role_enabled ? var.control_plane_roles : []
 }
 
 output "platform_iam_role_policy_arns" {
   description = "The platform IAM role policy arns"
-  value       = var.platform_user_enabled ? [] : local.truefoundry_platform_policy_arns
+  value       = var.platform_role_enabled ? local.truefoundry_platform_policy_arns : []
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -33,6 +33,12 @@ variable "cluster_name" {
 # IAM role
 ################################################################################
 
+variable "platform_role_enabled" {
+  description = "Enable creation of a platform feature IAM role"
+  type        = bool
+  default     = true
+}
+
 variable "control_plane_roles" {
   description = "Control plane roles that can assume your platform role"
   type        = list(string)

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,10 @@ variable "cluster_name" {
 ################################################################################
 
 variable "platform_role_enabled" {
+  validation {
+    condition     = !(var.platform_user_enabled && var.platform_role_enabled)
+    error_message = "Both platform_user_enabled and platform_role_enabled cannot be true at the same time. Please enable only one of them."
+  }
   description = "Enable creation of a platform feature IAM role"
   type        = bool
   default     = true


### PR DESCRIPTION
- Updated IAM role creation and policy attachments to depend on platform_role_enabled instead of platform_user_enabled.
- Modified output values to reflect the new role enabling logic.
- Introduced platform_role_enabled variable to control IAM role creation.
